### PR TITLE
fix: Apply zizmor recommendations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: 1.23
       - name: Generate Client
-        uses: grafana/shared-workflows/actions/generate-openapi-clients@main
+        uses: grafana/shared-workflows/actions/generate-openapi-clients@da511b720bc646fe01a29ddaf37e92df2c4bacb3
         with:
           package-name: gcom
           spec-path: openapi.json


### PR DESCRIPTION
**Changes in this PR**
- Applies the recommendations from [zizmor](https://woodruffw.github.io/zizmor/) to improve CI security
- Fixes:
  - [x] setting `persist-credentials: false`
  - [x] pinning action to a hash

**Reference**
- https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/
