### PR TITLE
Bump Go stdlib to 1.26.2 to fix critical CVEs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,21 @@ jobs:
           package-name: gcom
           spec-path: openapi.json
           modify-spec-script: .github/workflows/modify-spec.sh
+          commit-changes: "false"
         env:
           REPO_NAME: grafana-com-public-clients
+      - name: Pin Go module version
+        shell: bash
+        run: |
+          cd go/gcom
+          go mod edit -go=1.26.2
+          go mod tidy
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
+        if: github.event_name == 'push'
+        with:
+          commit_message: "Updating generated clients after openapi change"
+          commit_author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
 

--- a/go/gcom/go.mod
+++ b/go/gcom/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-com-public-clients/go/gcom
 
-go 1.18
+go 1.26.2
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/go/gcom/go.sum
+++ b/go/gcom/go.sum
@@ -1,13 +1,16 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/validator.v2 v2.0.1 h1:xF0KWyGWXm/LM2G1TrEjqOu4pa6coO9AlWSf3msVfDY=
 gopkg.in/validator.v2 v2.0.1/go.mod h1:lIUZBlB3Im4s/eYp39Ry/wkR02yOPhZ9IwIRBjuPuG8=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary

- Bumps the `go` directive in `go/gcom/go.mod` from `1.18` to `1.26.2`
- Adds a "Pin Go module version" step to the CI workflow (`publish.yml`) so future client regenerations pin to `1.26.2` instead of the generator's default `1.18`
- Disables the shared action's built-in commit and adds a separate commit step (matching the pattern used in `grafana-com-clients`)

## CVEs Fixed

| CVE | Severity | Fixed In |
|-----|----------|----------|
| CVE-2025-68121 | 10.0 | 1.26.0-rc.3 |
| CVE-2024-24790 | 9.8 | 1.22.4 |
| CVE-2023-24540 | 9.8 | 1.20.4 |
| CVE-2023-24538 | 9.8 | 1.20.3 |
| CVE-2025-22871 | 9.1 | 1.24.2 |
| CVE-2026-32282 | 7.8 | 1.26.2 |
| CVE-2023-29403 | 7.8 | 1.20.5 |

All vulnerabilities are in the Go stdlib and are resolved by updating to `go 1.26.2`.

## Why the workflow change?

The `openapi-generator-cli` regenerates `go/gcom/` from scratch on every run, creating a `go.mod` with `go 1.18`. Without the pin step, the next auto-generation would revert the fix. The private `grafana-com-clients` repo already had this pattern; this PR adds it to the public repo as well.

## No grafana-com changes needed

The `grafana-com` repo only pushes `openapi.json` spec updates to this repo (via `update-gcom-openapi-client.sh`). The Go version pinning is handled entirely within this repo's CI workflow.

## Test plan

- [ ] CI passes on the PR
- [ ] Verify the generated client still compiles with Go 1.26.2
- [ ] After merge, confirm the next auto-generation commit retains `go 1.26.2` in `go.mod`

Made with [Cursor](https://cursor.com)